### PR TITLE
Fix production build of webusb_site

### DIFF
--- a/webusb_site/src/webusb.js
+++ b/webusb_site/src/webusb.js
@@ -41,7 +41,7 @@ export function buildpacket(size, command) {
 }
 
 export function buildpacketWithFilename(size, command, filename) {
-    let {buffer, message_id} = buildpacket(filename.length+1+size, command, message_id);
+    let {buffer, message_id} = buildpacket(filename.length+1+size, command);
     for(let i = 0; i<filename.length; i++) {
         buffer[packetheadersize+i] = filename.charCodeAt(i);
     }


### PR DESCRIPTION
Fix message_id being used before declaration

This causes problems in case the production build where the code is restructured a bit differently than when running the site with yarn serve apparently.